### PR TITLE
only pass a reference to the function

### DIFF
--- a/2018-01-22-javascript-hard-parts/fem-JavaScriptTheHardParts-AsynchronicitySolutions.js
+++ b/2018-01-22-javascript-hard-parts/fem-JavaScriptTheHardParts-AsynchronicitySolutions.js
@@ -150,10 +150,12 @@ console.log('End of Challenge 5');
 //CHALLENGE 6//
 console.log('Start of Challenge 6');
 var dataReceived;
+var data; // is undefined at first
 
 function ajaxSimulate(id, callback) {
     var database = ['Aaron', 'Barbara', 'Chris'];
-    setTimeout(callback(database[id]), 0);
+    var data = database[id]
+    setTimeout(callback, 0); 
 }
 
 function storeData(data) {


### PR DESCRIPTION
this is conceptually wrong since the SetTimeout is going to exectue the callback immediately and the function never gets passed in the callback queue.

solution, leverage closure and set the database[id] in a global variable. 

```
var dataReceived;
var data; 

function ajaxSimulate(id, callback) {
    var database = ['Aaron', 'Barbara', 'Chris'];
    data = database[id]	
    setTimeout(callback, 0); 
}

function storeData() {
    dataReceived = data;
	console.log(dataReceived);
}

ajaxSimulate(1, storeData);
```