### PR TITLE
added limit check in challenge 18 snippet

### DIFF
--- a/javascript-hard-parts-v2/closures.js
+++ b/javascript-hard-parts-v2/closures.js
@@ -396,8 +396,11 @@ function makeHistory(limit) {
       }
       return `${history.pop()} undone`;
     } 
+    if (history.length === limit) {
+      history.shift();
+    }
     
-    history.push(str)
+    history.push(str);
     return `${str} done`
     
   }


### PR DESCRIPTION
Hi there, I was doing this exercise and I realize that the code in the repo does not check for the limit argument passed-in. 
`function makeHistory(limit){...}`
```
// /*** Uncomment these to check your work! ***/
const myActions = makeHistory(2);
/*
console.log(myActions('jump')); // => should log 'jump done'
console.log(myActions('undo')); // => should log 'jump undone'
console.log(myActions('walk')); // => should log 'walk done'
console.log(myActions('code')); // => should log 'code done'
console.log(myActions('pose')); // => should log 'pose done'
console.log(myActions('undo')); // => should log 'pose undone'
console.log(myActions('undo')); // => should log 'code undone'
console.log(myActions('undo')); // => should log 'walk undone' <<< undone 3 elements
console.log(myActions('undo')); // => should log 'nothing to undo'
*/
```
If you compare it with [csbin](http://csbin.io/closures) "should log" statements you will see the difference.  
```
// /*** Uncomment these to check your work! ***/
 const myActions = makeHistory(2);
// console.log(myActions('jump')); // => should log 'jump done'
// console.log(myActions('undo')); // => should log 'jump undone'
// console.log(myActions('walk')); // => should log 'walk done'
// console.log(myActions('code')); // => should log 'code done'
// console.log(myActions('pose')); // => should log 'pose done'
// console.log(myActions('undo')); // => should log 'pose undone'
// console.log(myActions('undo')); // => should log 'code undone'
// console.log(myActions('undo')); // => should log 'nothing to undo' <<<< checked limit
```

I hope I've been helpful.